### PR TITLE
Enhance docs structure and API pages

### DIFF
--- a/content/docs/api-docs/callbacks/receive-run-status-updates-via-webhook.mdx
+++ b/content/docs/api-docs/callbacks/receive-run-status-updates-via-webhook.mdx
@@ -3,3 +3,6 @@ title: Run Update
 description: Receive run status updates via webhook
 openapi: webhook {$request.body#/webhook}
 ---
+
+Configure a webhook endpoint to receive JSON updates whenever the run state
+changes. Each event is sent as a POST request containing the run payload.

--- a/content/docs/api-docs/meta.json
+++ b/content/docs/api-docs/meta.json
@@ -6,5 +6,6 @@
     "run/cancel-run",
     "callbacks/receive-run-status-updates-via-webhook"
   ],
-  "defaultOpen": true
+  "defaultOpen": true,
+  "root": true
 } 

--- a/content/docs/api-docs/run/cancel-run.mdx
+++ b/content/docs/api-docs/run/cancel-run.mdx
@@ -3,3 +3,5 @@ title: Cancel Run
 description: Cancel a running workflow execution
 openapi: post /run/{run_id}/cancel
 ---
+
+Abort a running workflow before completion. Returns the cancelled run object.

--- a/content/docs/api-docs/run/deployment-queue.mdx
+++ b/content/docs/api-docs/run/deployment-queue.mdx
@@ -3,3 +3,6 @@ title: Queue Run
 description: Queue a new run for a deployment
 openapi: post /run/deployment/queue
 ---
+
+Use this endpoint to queue a workflow run for a deployment. The response
+contains the new run ID which can be used with the **Get Run** endpoint.

--- a/content/docs/api-docs/run/get-run.mdx
+++ b/content/docs/api-docs/run/get-run.mdx
@@ -3,3 +3,5 @@ title: Get Run
 description: Get the status and details of a specific run
 openapi: get /run/{run_id}
 ---
+
+Retrieve the status and metadata of a run using its `run_id`.

--- a/content/docs/meta.json
+++ b/content/docs/meta.json
@@ -1,17 +1,23 @@
 {
-  "title": "ComfyDeploy Documentation",
+  "title": "Dashboard",
   "pages": [
+    "---Getting Started---",
     "introduction",
     "workspace/overview",
     "workflows/import",
+    "---Manage Resources---",
     "machines",
     "models/download",
     "deployments",
+    "---Team---",
     "team",
+    "---Guides---",
     "data/data-flow",
     "integration/custom-s3",
     "nextjs",
+    "---API---",
     "api-docs",
+    "---Upgrade---",
     "upgrade/v2"
   ],
   "root": true

--- a/src/app/docs/layout.tsx
+++ b/src/app/docs/layout.tsx
@@ -5,7 +5,7 @@ import { source } from '@/lib/source';
 
 export default function Layout({ children }: { children: ReactNode }) {
   return (
-    <DocsLayout tree={source.pageTree} {...baseOptions}>
+    <DocsLayout tree={source.pageTree} {...baseOptions} sidebar={{ tabs: true }}>
       {children}
     </DocsLayout>
   );


### PR DESCRIPTION
## Summary
- group sidebar items for better navigation
- enable Dashboard/API tabs in docs layout
- flesh out API reference pages

## Testing
- `bun i`
- `bun dev` *(server started)*

------
https://chatgpt.com/codex/tasks/task_b_685a2f1ad6f88322b1a4e35d565b47e6